### PR TITLE
Inject heartbeat to sematext output

### DIFF
--- a/plugins/outputs/sematext/processors/heartbeat.go
+++ b/plugins/outputs/sematext/processors/heartbeat.go
@@ -8,13 +8,25 @@ import (
 )
 
 const (
-	oneMinuteSeconds int64 = 60
+	oneMinuteSeconds = int64(60)
+	oneHourMinutes   = int64(60)
+	oneDaySeconds    = 24 * oneHourMinutes * oneMinuteSeconds
+	oneDayMinutes    = 24 * oneHourMinutes
 )
 
-// Heartbeat is a batch processor that injects heartbeat metric as necessary (once per minute).
+// Heartbeat is a batch processor that injects heartbeat metric as necessary (once per minute). It stores info about
+// already injected heartbeats (one per minute) into injectedMinutes field. It will clear this map once a day to avoid
+// it to grow too big (field mapResetDay keeps the record of the "day" for which injectedMinutes contains the data)
 type Heartbeat struct {
-	lastInjectedMinute int64
-	lock               sync.Mutex
+	injectedMinutes map[int64]bool
+	mapResetDay     int64
+	lock            sync.Mutex
+}
+
+func NewHeartbeat() *Heartbeat {
+	return &Heartbeat{
+		injectedMinutes: make(map[int64]bool),
+	}
 }
 
 // Process is a method where Heartbeat processor checks whether a heartbeat metric is needed and injects it if so
@@ -22,36 +34,54 @@ func (h *Heartbeat) Process(metrics []telegraf.Metric) ([]telegraf.Metric, error
 	h.lock.Lock()
 	defer h.lock.Unlock()
 
-	now := time.Now()
-	if h.heartbeatNeeded(now) {
-		// a heartbeat metric will be added to the batch with "current" timestamp regardless of whether the batch
-		// is a fresh one or is being resent because of an earlier failure - the only important things are that it is
-		// created and that we try to send it as soon as possible
-		newMetrics, err := h.addHeartbeat(metrics, now)
+	h.resetMap()
 
-		if err != nil {
-			return metrics, err
+	minutes := findMetricMinutes(metrics)
+
+	for minute, timeSeconds := range minutes {
+		if h.heartbeatNeeded(minute) {
+			newMetrics, err := h.addHeartbeat(metrics, minute, timeSeconds)
+
+			if err != nil {
+				return metrics, err
+			}
+
+			metrics = newMetrics
 		}
-
-		metrics = newMetrics
 	}
 
 	return metrics, nil
 }
 
-func (h *Heartbeat) addHeartbeat(metrics []telegraf.Metric, now time.Time) ([]telegraf.Metric, error) {
-	hb, err := h.createHeartbeat(now)
+func findMetricMinutes(metrics []telegraf.Metric) map[int64]int64 {
+	// holds a mapping between a minute and the "biggest" timestamp (in seconds) found for that minute
+	minMap := make(map[int64]int64)
+
+	for _, metric := range metrics {
+		min := getEpochMinute(metric.Time())
+		seconds := metric.Time().Unix()
+
+		if seconds > minMap[min] {
+			minMap[min] = seconds
+		}
+	}
+
+	return minMap
+}
+
+func (h *Heartbeat) addHeartbeat(metrics []telegraf.Metric, minute int64, timeSeconds int64) ([]telegraf.Metric, error) {
+	hb, err := buildHeartbeatMetric(time.Unix(timeSeconds, 0))
 	if err != nil {
 		return nil, err
 	}
 
 	metrics = append(metrics, hb)
-	h.lastInjectedMinute = getEpochMinute(now)
+	h.injectedMinutes[minute] = true
 
 	return metrics, nil
 }
 
-func (h *Heartbeat) createHeartbeat(timestamp time.Time) (telegraf.Metric, error) {
+func buildHeartbeatMetric(timestamp time.Time) (telegraf.Metric, error) {
 	// no need to inject any Sematext specific tags since MetricProcessors will be run afterwards and will take care
 	// of such things
 	hb, err := metric.New("heartbeat",
@@ -66,9 +96,21 @@ func (h *Heartbeat) createHeartbeat(timestamp time.Time) (telegraf.Metric, error
 	return hb, nil
 }
 
-func (h *Heartbeat) heartbeatNeeded(now time.Time) bool {
-	nowMinute := getEpochMinute(now)
-	return nowMinute > h.lastInjectedMinute
+func (h *Heartbeat) heartbeatNeeded(minute int64) bool {
+	return !h.injectedMinutes[minute]
+}
+
+func (h *Heartbeat) resetMap() {
+	day := getEpochDay(time.Now())
+
+	if day > h.mapResetDay {
+		h.injectedMinutes = make(map[int64]bool, oneDayMinutes)
+		h.mapResetDay = day
+	}
+}
+
+func getEpochDay(time time.Time) int64 {
+	return time.Unix() / oneDaySeconds
 }
 
 func getEpochMinute(time time.Time) int64 {

--- a/plugins/outputs/sematext/processors/heartbeat.go
+++ b/plugins/outputs/sematext/processors/heartbeat.go
@@ -1,0 +1,68 @@
+package processors
+
+import (
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"time"
+)
+
+const (
+	oneMinuteSeconds int64 = 60
+)
+
+// Heartbeat is a batch processor that injects heartbeat metric as necessary (once per minute)
+type Heartbeat struct {
+	lastInjectedMinute int64
+}
+
+// Process is a method where Heartbeat processor logic is implemented
+func (t *Heartbeat) Process(metrics []telegraf.Metric) ([]telegraf.Metric, error) {
+	now := time.Now()
+	if t.heartbeatNeeded(now) {
+		newMetrics, err := t.addHeartbeat(metrics, now)
+
+		if err != nil {
+			return metrics, err
+		}
+
+		metrics = newMetrics
+	}
+
+	return metrics, nil
+}
+
+func (t *Heartbeat) addHeartbeat(metrics []telegraf.Metric, now time.Time) ([]telegraf.Metric, error) {
+	hb, err := t.createHeartbeat(now)
+	if err != nil {
+		return nil, err
+	}
+
+	metrics = append(metrics, hb)
+	t.lastInjectedMinute = getEpochMinute(now)
+
+	return metrics, nil
+}
+
+func (t *Heartbeat) createHeartbeat(timestamp time.Time) (telegraf.Metric, error) {
+	// no need to inject any Sematext specific tags since MetricProcessors will be run afterwards and will take care
+	// of such things
+	hb, err := metric.New("heartbeat",
+		make(map[string]string),
+		map[string]interface{}{"alive": int64(1)},
+		timestamp, telegraf.Gauge)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return hb, nil
+}
+
+func (t *Heartbeat) heartbeatNeeded(now time.Time) bool {
+	nowMinute := getEpochMinute(now)
+	return nowMinute > t.lastInjectedMinute
+}
+
+func getEpochMinute(time time.Time) int64 {
+	return time.Unix() / oneMinuteSeconds
+}

--- a/plugins/outputs/sematext/processors/heartbeat.go
+++ b/plugins/outputs/sematext/processors/heartbeat.go
@@ -10,15 +10,18 @@ const (
 	oneMinuteSeconds int64 = 60
 )
 
-// Heartbeat is a batch processor that injects heartbeat metric as necessary (once per minute)
+// Heartbeat is a batch processor that injects heartbeat metric as necessary (once per minute).
 type Heartbeat struct {
 	lastInjectedMinute int64
 }
 
-// Process is a method where Heartbeat processor logic is implemented
+// Process is a method where Heartbeat processor checks whether a heartbeat metric is needed and injects it if so
 func (t *Heartbeat) Process(metrics []telegraf.Metric) ([]telegraf.Metric, error) {
 	now := time.Now()
 	if t.heartbeatNeeded(now) {
+		// a heartbeat metric will be added to the batch with "current" timestamp regardless of whether the batch
+		// is a fresh one or is being resent because of an earlier failure - the only important things are that it is
+		// created and that we try to send it as soon as possible
 		newMetrics, err := t.addHeartbeat(metrics, now)
 
 		if err != nil {

--- a/plugins/outputs/sematext/processors/heartbeat_test.go
+++ b/plugins/outputs/sematext/processors/heartbeat_test.go
@@ -1,0 +1,69 @@
+package processors
+
+import (
+	"github.com/influxdata/telegraf"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestCreateHeartbeat(t *testing.T) {
+	h := &Heartbeat{}
+
+	now := time.Now()
+	metric, err := h.createHeartbeat(now)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "heartbeat", metric.Name())
+	assert.Equal(t, 1, len(metric.Fields()))
+	val, set := metric.GetField("alive")
+	assert.Equal(t, true, set)
+	assert.Equal(t, int64(1), val)
+	assert.Equal(t, 0, len(metric.Tags()))
+}
+
+func TestHeartbeatNeeded(t *testing.T) {
+	now := time.Now()
+	currentMinute := getEpochMinute(now)
+	h := &Heartbeat{}
+	assert.Equal(t, true, h.heartbeatNeeded(now))
+
+	h.lastInjectedMinute = currentMinute
+	assert.Equal(t, false, h.heartbeatNeeded(now))
+
+	h.lastInjectedMinute = currentMinute - 1
+	assert.Equal(t, true, h.heartbeatNeeded(now))
+
+	h.lastInjectedMinute = currentMinute + 1
+	assert.Equal(t, false, h.heartbeatNeeded(now))
+}
+
+func TestAddHeartbeat(t *testing.T) {
+	now := time.Now()
+	currentMinute := getEpochMinute(now)
+	h := &Heartbeat{
+		lastInjectedMinute: currentMinute - 1,
+	}
+
+	metrics := make([]telegraf.Metric, 0, 1)
+	var err error
+	metrics, err = h.addHeartbeat(metrics, now)
+
+	assert.Nil(t, err)
+	assert.Equal(t, currentMinute, h.lastInjectedMinute)
+	assert.Equal(t, 1, len(metrics))
+}
+
+func TestProcess(t *testing.T) {
+	h := &Heartbeat{}
+	metrics := make([]telegraf.Metric, 0, 1)
+
+	assert.Equal(t, int64(0), h.lastInjectedMinute)
+
+	var err error
+	metrics, err = h.Process(metrics)
+
+	assert.Nil(t, err)
+	assert.NotEqual(t, int64(0), h.lastInjectedMinute)
+	assert.Equal(t, 1, len(metrics))
+}

--- a/plugins/outputs/sematext/processors/processor.go
+++ b/plugins/outputs/sematext/processors/processor.go
@@ -3,13 +3,15 @@ package processors
 import "github.com/influxdata/telegraf"
 
 // MetricProcessor is interface that should be implemented by modules which adjust Telegraf metrics to match Sematext
-// format
+// format.
 type MetricProcessor interface {
 	// Process makes adjustments to a single metric instance to be compliant with Sematext backend
 	Process(metric telegraf.Metric) error
 }
 
-// BatchProcessor is used to execute actions on the level of a whole batch of metrics.
+// BatchProcessor is used to execute actions on the level of a whole batch of metrics. Batch processors are run before
+// any Metric processors kick in, so metrics produced by a batch processor can count on further being decorated by
+// metric processors.
 type BatchProcessor interface {
 	Process(metrics []telegraf.Metric) ([]telegraf.Metric, error)
 }

--- a/plugins/outputs/sematext/processors/processor.go
+++ b/plugins/outputs/sematext/processors/processor.go
@@ -2,7 +2,14 @@ package processors
 
 import "github.com/influxdata/telegraf"
 
-// Processor is interface that should be implemented by modules which adjust Telegraf metrics to match Sematext format
-type Processor interface {
+// MetricProcessor is interface that should be implemented by modules which adjust Telegraf metrics to match Sematext
+// format
+type MetricProcessor interface {
+	// Process makes adjustments to a single metric instance to be compliant with Sematext backend
 	Process(metric telegraf.Metric) error
+}
+
+// BatchProcessor is used to execute actions on the level of a whole batch of metrics.
+type BatchProcessor interface {
+	Process(metrics []telegraf.Metric) ([]telegraf.Metric, error)
 }

--- a/plugins/outputs/sematext/processors/token.go
+++ b/plugins/outputs/sematext/processors/token.go
@@ -12,3 +12,10 @@ func (t *Token) Process(metric telegraf.Metric) error {
 	metric.AddTag("token", t.Token)
 	return nil
 }
+
+// NewToken creates a new token processor
+func NewToken(token string) *Token {
+	return &Token{
+		Token: token,
+	}
+}

--- a/plugins/outputs/sematext/sematext.go
+++ b/plugins/outputs/sematext/sematext.go
@@ -95,12 +95,10 @@ func (s *Sematext) Init() error {
 func (s *Sematext) initProcessors() {
 	// add more processors as they are implemented
 	s.metricProcessors = []processors.MetricProcessor{
-		&processors.Token{
-			Token: s.Token,
-		},
+		processors.NewToken(s.Token),
 	}
 	s.batchProcessors = []processors.BatchProcessor{
-		&processors.Heartbeat{},
+		processors.NewHeartbeat(),
 	}
 }
 

--- a/plugins/outputs/sematext/sematext.go
+++ b/plugins/outputs/sematext/sematext.go
@@ -99,7 +99,9 @@ func (s *Sematext) initProcessors() {
 			Token: s.Token,
 		},
 	}
-	s.batchProcessors = []processors.BatchProcessor{}
+	s.batchProcessors = []processors.BatchProcessor{
+		&processors.Heartbeat{},
+	}
 }
 
 // Write sends metrics to Sematext backend and handles the response

--- a/plugins/outputs/sematext/sematext.go
+++ b/plugins/outputs/sematext/sematext.go
@@ -26,11 +26,12 @@ type Sematext struct {
 	Password    string          `toml:"password"`
 	Log         telegraf.Logger `toml:"-"`
 
-	metricsURL   string
-	sender       *sender.Sender
-	senderConfig *sender.Config
-	serializer   serializer.MetricSerializer
-	processors   []processors.Processor
+	metricsURL       string
+	sender           *sender.Sender
+	senderConfig     *sender.Config
+	serializer       serializer.MetricSerializer
+	metricProcessors []processors.MetricProcessor
+	batchProcessors  []processors.BatchProcessor
 }
 
 // TODO add real sample config
@@ -93,16 +94,21 @@ func (s *Sematext) Init() error {
 // initProcessors instantiates all metric processors that will be used to prepare metrics/tags for sending to Sematext
 func (s *Sematext) initProcessors() {
 	// add more processors as they are implemented
-	s.processors = []processors.Processor{
+	s.metricProcessors = []processors.MetricProcessor{
 		&processors.Token{
 			Token: s.Token,
 		},
 	}
+	s.batchProcessors = []processors.BatchProcessor{}
 }
 
 // Write sends metrics to Sematext backend and handles the response
 func (s *Sematext) Write(metrics []telegraf.Metric) error {
-	processedMetrics := s.processMetrics(metrics)
+	processedMetrics, err := s.processMetrics(metrics)
+
+	if err != nil {
+		s.Log.Errorf("error while preparing to send metrics to Sematext: %v", err)
+	}
 
 	if len(processedMetrics) > 0 {
 		body := s.serializer.Write(processedMetrics)
@@ -127,12 +133,22 @@ func (s *Sematext) Write(metrics []telegraf.Metric) error {
 	return nil
 }
 
-func (s *Sematext) processMetrics(metrics []telegraf.Metric) []telegraf.Metric {
+func (s *Sematext) processMetrics(metrics []telegraf.Metric) ([]telegraf.Metric, error) {
+	for _, p := range s.batchProcessors {
+		var err error
+		metrics, err = p.Process(metrics)
+
+		if err != nil {
+			s.Log.Errorf("error while running batch processors in Sematext output: %v", err)
+			return metrics, err
+		}
+	}
+
 	processedMetrics := make([]telegraf.Metric, 0, len(metrics))
 
 	for _, metric := range metrics {
 		metricOk := true
-		for _, p := range s.processors {
+		for _, p := range s.metricProcessors {
 			err := p.Process(metric)
 
 			if err != nil {
@@ -146,7 +162,7 @@ func (s *Sematext) processMetrics(metrics []telegraf.Metric) []telegraf.Metric {
 			processedMetrics = append(processedMetrics, metric)
 		}
 	}
-	return processedMetrics
+	return processedMetrics, nil
 }
 
 // TODO may not be needed as we have to rework how retry logic works depending on response status codes; sometimes

--- a/plugins/outputs/sematext/sematext.go
+++ b/plugins/outputs/sematext/sematext.go
@@ -109,7 +109,10 @@ func (s *Sematext) Write(metrics []telegraf.Metric) error {
 	processedMetrics, err := s.processMetrics(metrics)
 
 	if err != nil {
-		s.Log.Errorf("error while preparing to send metrics to Sematext: %v", err)
+		// error means the whole batch should be discarded without sending it. To achieve that, we have to return
+		// nil
+		s.Log.Errorf("error while preparing to send metrics to Sematext, the batch will be dropped: %v", err)
+		return nil
 	}
 
 	if len(processedMetrics) > 0 {
@@ -135,6 +138,7 @@ func (s *Sematext) Write(metrics []telegraf.Metric) error {
 	return nil
 }
 
+// processMetrics returns an error only when the whole batch of metrics should be discarded
 func (s *Sematext) processMetrics(metrics []telegraf.Metric) ([]telegraf.Metric, error) {
 	for _, p := range s.batchProcessors {
 		var err error


### PR DESCRIPTION
- Introduced BatchProcessors which operate on the level of a whole batch of metrics and can modify the batch content
- Renamed existing metric Processor interface to MetricProcessor
- Implemented Heartbeat processor which periodically (at most once a minute) injects heartbeat.alive metric - this was implemented in a generic way and depends on the presence of metric batches for monitored service. This meant we don't have to implement service specific heartbeat query/request for each possible integration, however, the downside is that it is not completely reliable (it is a similar approach to what we are using in Java AAs)