### PR TITLE
Create Host Processor

### DIFF
--- a/plugins/outputs/sematext/processors/heartbeat.go
+++ b/plugins/outputs/sematext/processors/heartbeat.go
@@ -53,6 +53,9 @@ func (h *Heartbeat) Process(metrics []telegraf.Metric) ([]telegraf.Metric, error
 	return metrics, nil
 }
 
+// Close clears the resources processor used, no-op in this case
+func (h *Heartbeat) Close() {}
+
 func findMetricMinutes(metrics []telegraf.Metric) map[int64]int64 {
 	// holds a mapping between a minute and the "biggest" timestamp (in seconds) found for that minute
 	minMap := make(map[int64]int64)

--- a/plugins/outputs/sematext/processors/host.go
+++ b/plugins/outputs/sematext/processors/host.go
@@ -4,6 +4,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"io/ioutil"
 	"path"
+	"strings"
 	"sync"
 	"time"
 )
@@ -113,5 +114,6 @@ func loadHostname(hostnameFileName string) (string, error) {
 		return "", err
 	}
 
-	return string(data), nil
+	fullStr := string(data)
+	return strings.Split(fullStr, "\n")[0], nil
 }

--- a/plugins/outputs/sematext/processors/host.go
+++ b/plugins/outputs/sematext/processors/host.go
@@ -1,0 +1,90 @@
+package processors
+
+import (
+	"bufio"
+	"github.com/influxdata/telegraf"
+	"os"
+	"path"
+	"sync"
+	"time"
+)
+
+const (
+	sematextHostTag  = "os.host"
+	telegrafHostTag  = "host"
+	hostnameFileName = ".resolved-hostname"
+)
+
+type Host struct {
+	hostname string
+	lock     sync.RWMutex
+}
+
+// NewHost creates and initializes an instance of Host processor. It also starts periodic host reload goroutine.
+func NewHost() *Host {
+	// do the initial load before spawning a goroutine which will periodically reload the hostname
+	hostnameFileName := getHostnameFileName()
+	h := &Host{
+		hostname: loadHostname(hostnameFileName),
+	}
+
+	// if the Sematext dir (which might hold the hostname file) doesn't exist, no point in starting the goroutine
+	if hostnameFileName != "" {
+		go func() {
+			for {
+				time.Sleep(2 * time.Minute)
+
+				h.lock.Lock()
+				loadHostname(hostnameFileName)
+				h.lock.Unlock()
+			}
+		}()
+	}
+
+	return h
+}
+
+// Process adjusts the host tag to be compliant with Sematext backend
+func (h *Host) Process(metric telegraf.Metric) error {
+	// locking because of h.hostname which might be written to by a separate goroutine
+	h.lock.RLock()
+	defer h.lock.RUnlock()
+
+	adjustHostname(metric, h.hostname)
+
+	return nil
+}
+
+func adjustHostname(metric telegraf.Metric, loadedHostname string) {
+	if loadedHostname != "" {
+		metric.RemoveTag(telegrafHostTag)
+		metric.AddTag(sematextHostTag, loadedHostname)
+	} else {
+		h, set := metric.GetTag(telegrafHostTag)
+		if set {
+			metric.RemoveTag(telegrafHostTag)
+			metric.AddTag(sematextHostTag, h)
+		}
+	}
+}
+
+func getHostnameFileName() string {
+	if root := GetRootDir(); root != "" {
+		return path.Join(root, hostnameFileName)
+	}
+	return ""
+}
+
+func loadHostname(hostnameFile string) string {
+	file, err := os.Open(hostnameFile)
+	if err != nil {
+		return ""
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Scan()
+	hostname := scanner.Text()
+
+	return hostname
+}

--- a/plugins/outputs/sematext/processors/host_test.go
+++ b/plugins/outputs/sematext/processors/host_test.go
@@ -32,7 +32,7 @@ func TestLoadHostname(t *testing.T) {
 	assert.Equal(t, "somehost001", onlyHost(loadHostname("./testdata/resolved-hostname-multiline2")))
 }
 
-func onlyHost(host string, err error) string {
+func onlyHost(host string, _ error) string {
 	return host
 }
 

--- a/plugins/outputs/sematext/processors/host_test.go
+++ b/plugins/outputs/sematext/processors/host_test.go
@@ -25,11 +25,15 @@ func TestAdjustHostname(t *testing.T) {
 }
 
 func TestLoadHostname(t *testing.T) {
-	assert.Equal(t, "somehost001", loadHostname("./testdata/resolved-hostname"))
-	assert.Equal(t, "", loadHostname("./testdata/doesnt-exist"))
-	assert.Equal(t, "", loadHostname("/baddir"))
-	assert.Equal(t, "somehost001", loadHostname("./testdata/resolved-hostname-multiline"))
-	assert.Equal(t, "somehost001", loadHostname("./testdata/resolved-hostname-multiline2"))
+	assert.Equal(t, "somehost001", onlyHost(loadHostname("./testdata/resolved-hostname")))
+	assert.Equal(t, "", onlyHost(loadHostname("./testdata/doesnt-exist")))
+	assert.Equal(t, "", onlyHost(loadHostname("/baddir")))
+	assert.Equal(t, "somehost001", onlyHost(loadHostname("./testdata/resolved-hostname-multiline")))
+	assert.Equal(t, "somehost001", onlyHost(loadHostname("./testdata/resolved-hostname-multiline2")))
+}
+
+func onlyHost(host string, err error) string {
+	return host
 }
 
 func TestHostProcess(t *testing.T) {

--- a/plugins/outputs/sematext/processors/host_test.go
+++ b/plugins/outputs/sematext/processors/host_test.go
@@ -1,0 +1,55 @@
+package processors
+
+import (
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestAdjustHostname(t *testing.T) {
+	now := time.Now()
+
+	m, _ := metric.New(
+		"os",
+		map[string]string{telegrafHostTag: "somehost", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
+		now)
+
+	adjustHostname(m, "abc")
+
+	newVal, set := m.GetTag(sematextHostTag)
+
+	assert.Equal(t, true, set)
+	assert.Equal(t, "abc", newVal)
+}
+
+func TestLoadHostname(t *testing.T) {
+	assert.Equal(t, "somehost001", loadHostname("./testdata/resolved-hostname"))
+	assert.Equal(t, "", loadHostname("./testdata/doesnt-exist"))
+	assert.Equal(t, "", loadHostname("/baddir"))
+	assert.Equal(t, "somehost001", loadHostname("./testdata/resolved-hostname-multiline"))
+	assert.Equal(t, "somehost001", loadHostname("./testdata/resolved-hostname-multiline2"))
+}
+
+func TestHostProcess(t *testing.T) {
+	h := &Host{
+		hostname: "abc",
+	}
+
+	now := time.Now()
+
+	m, _ := metric.New(
+		"os",
+		map[string]string{telegrafHostTag: "somehost", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
+		now)
+
+	err := h.Process(m)
+	assert.Nil(t, err)
+
+	newVal, set := m.GetTag(sematextHostTag)
+
+	assert.Equal(t, true, set)
+	assert.Equal(t, "abc", newVal)
+}

--- a/plugins/outputs/sematext/processors/processor.go
+++ b/plugins/outputs/sematext/processors/processor.go
@@ -7,6 +7,8 @@ import "github.com/influxdata/telegraf"
 type MetricProcessor interface {
 	// Process makes adjustments to a single metric instance to be compliant with Sematext backend
 	Process(metric telegraf.Metric) error
+
+	Close()
 }
 
 // BatchProcessor is used to execute actions on the level of a whole batch of metrics. Batch processors are run before
@@ -14,4 +16,6 @@ type MetricProcessor interface {
 // metric processors.
 type BatchProcessor interface {
 	Process(metrics []telegraf.Metric) ([]telegraf.Metric, error)
+
+	Close()
 }

--- a/plugins/outputs/sematext/processors/testdata/resolved-hostname
+++ b/plugins/outputs/sematext/processors/testdata/resolved-hostname
@@ -1,0 +1,1 @@
+somehost001

--- a/plugins/outputs/sematext/processors/testdata/resolved-hostname-multiline
+++ b/plugins/outputs/sematext/processors/testdata/resolved-hostname-multiline
@@ -1,0 +1,1 @@
+somehost001

--- a/plugins/outputs/sematext/processors/testdata/resolved-hostname-multiline2
+++ b/plugins/outputs/sematext/processors/testdata/resolved-hostname-multiline2
@@ -1,0 +1,2 @@
+somehost001
+someotherhost002

--- a/plugins/outputs/sematext/processors/token.go
+++ b/plugins/outputs/sematext/processors/token.go
@@ -13,6 +13,9 @@ func (t *Token) Process(metric telegraf.Metric) error {
 	return nil
 }
 
+// Close clears the resources processor used, no-op in this case
+func (t *Token) Close() {}
+
 // NewToken creates a new token processor
 func NewToken(token string) *Token {
 	return &Token{

--- a/plugins/outputs/sematext/processors/utils.go
+++ b/plugins/outputs/sematext/processors/utils.go
@@ -1,0 +1,32 @@
+package processors
+
+import (
+	"os"
+)
+
+const (
+	RootEnvVar     = "SPM_ROOT"
+	DefaultRootDir = "/opt/spm/"
+)
+
+// GetRootDir returns the root dir of Sematext Agent installation, if it is present. Otherwise empty string.
+func GetRootDir() string {
+	if dir := os.Getenv(RootEnvVar); dir != "" {
+		if exists(dir) {
+			return dir
+		}
+	}
+
+	if exists(DefaultRootDir) {
+		return DefaultRootDir
+	}
+
+	return ""
+}
+
+func exists(dir string) bool {
+	if _, err := os.Stat(dir); err != nil {
+		return false
+	}
+	return true
+}

--- a/plugins/outputs/sematext/sematext.go
+++ b/plugins/outputs/sematext/sematext.go
@@ -105,7 +105,7 @@ func (s *Sematext) initProcessors() {
 	// add more processors as they are implemented
 	s.metricProcessors = []processors.MetricProcessor{
 		processors.NewToken(s.Token),
-		processors.NewHost(),
+		processors.NewHost(s.Log),
 	}
 	s.batchProcessors = []processors.BatchProcessor{
 		processors.NewHeartbeat(),

--- a/plugins/outputs/sematext/sematext.go
+++ b/plugins/outputs/sematext/sematext.go
@@ -47,6 +47,15 @@ func (s *Sematext) Connect() error {
 // Close Closes the Sematext output
 func (s *Sematext) Close() error {
 	s.sender.Close()
+
+	for _, mp := range s.metricProcessors {
+		mp.Close()
+	}
+
+	for _, bp := range s.batchProcessors {
+		bp.Close()
+	}
+
 	return nil
 }
 
@@ -96,6 +105,7 @@ func (s *Sematext) initProcessors() {
 	// add more processors as they are implemented
 	s.metricProcessors = []processors.MetricProcessor{
 		processors.NewToken(s.Token),
+		processors.NewHost(),
 	}
 	s.batchProcessors = []processors.BatchProcessor{
 		processors.NewHeartbeat(),


### PR DESCRIPTION
Host processor is used to:
- ensure there is `os.host` attached to all metrics, as expected by Sematext backend
- try to load the hostname from `.resolved-hostname` if Sematext Agent installation is present on the machine and use that hostname as `os.host` tag
- if it doesn't exist, use the hostname from `host` tag added by Telegraf; also remove that tag from the metric