### PR TITLE
Extract and send metainfo to Sematext backend

### DIFF
--- a/plugins/outputs/sematext/processors/host.go
+++ b/plugins/outputs/sematext/processors/host.go
@@ -85,6 +85,7 @@ func (h *Host) Close() {
 	if h.stopReload != nil {
 		h.stopReload <- true
 	}
+	h.reloadTicker.Stop()
 }
 
 func adjustHostname(metric telegraf.Metric, loadedHostname string) {

--- a/plugins/outputs/sematext/processors/metainfo.go
+++ b/plugins/outputs/sematext/processors/metainfo.go
@@ -1,0 +1,158 @@
+package processors
+
+import (
+	"fmt"
+	"github.com/influxdata/telegraf"
+	"sync"
+)
+
+// MetricMetainfo contains metainfo about a single metric
+type MetricMetainfo struct {
+	token       string
+	name        string
+	namespace   string
+	semType     SematextMetricType
+	numericType NumericType
+	label       string
+	description string
+	host        string
+}
+
+// SematextMetricType is an enumeration of metric types expected by Sematext backend
+type SematextMetricType int
+
+// Possible values for the ValueType enum.
+const (
+	_ SematextMetricType = iota
+	Counter
+	Gauge
+)
+
+// NumericType represents metric's data type
+type NumericType int
+
+const (
+	UnsupportedNumericType NumericType = iota
+	Long
+	Double
+	Bool
+)
+
+// Metainfo is a processor that extracts metainfo from telegraf metrics and sends it to Sematext backend
+type Metainfo struct {
+	log         telegraf.Logger
+	token       string
+	sentMetrics map[string]*MetricMetainfo
+	lock        sync.Mutex
+}
+
+// NewMetainfo creates a new Metainfo processor
+func NewMetainfo(log telegraf.Logger, token string) *Metainfo {
+	sentMetricsMap := make(map[string]*MetricMetainfo)
+	return &Metainfo{
+		log:         log,
+		token:       token,
+		sentMetrics: sentMetricsMap,
+	}
+}
+
+// Process contains core logic of Metainfo processor
+func (m *Metainfo) Process(metrics []telegraf.Metric) ([]telegraf.Metric, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	newMetrics := make([]*MetricMetainfo, 0)
+
+	for _, metric := range metrics {
+		for _, field := range metric.FieldList() {
+			mInfo := processMetric(m.token, &metric, field, &m.sentMetrics)
+			if mInfo != nil {
+				newMetrics = append(newMetrics, mInfo)
+			}
+		}
+	}
+
+	if len(newMetrics) > 0 {
+		// TODO send the metainfo
+		// TODO add newMetrics to sentMetrics (maybe right away, don't wait for goroutine to finish because of locks)
+	}
+
+	return metrics, nil
+}
+
+func processMetric(token string, metric *telegraf.Metric, field *telegraf.Field,
+	sentMetrics *map[string]*MetricMetainfo) *MetricMetainfo {
+	host, set := (*metric).GetTag(telegrafHostTag)
+	// skip if no host tag
+	if set {
+		key := buildMetricKey(host, (*metric).Name(), field.Key)
+
+		_, set := (*sentMetrics)[key]
+		if !set {
+			return buildMetainfo(token, host, metric, field)
+		}
+	}
+
+	return nil
+}
+
+func buildMetainfo(token string, host string, metric *telegraf.Metric, field *telegraf.Field) *MetricMetainfo {
+	semType := getSematextMetricType((*metric).Type())
+	numericType := getSematextNumericType(field)
+
+	if numericType == UnsupportedNumericType {
+		return nil
+	}
+
+	label := fmt.Sprintf("%s.%s", (*metric).Name(), field.Key)
+
+	return &MetricMetainfo{
+		token:       token,
+		name:        field.Key,
+		namespace:   (*metric).Name(),
+		semType:     semType,
+		numericType: numericType,
+		label:       label,
+		description: "",
+		host:        host,
+	}
+}
+
+// Close clears the resources used by Metainfo processor
+func (m *Metainfo) Close() {
+	// TODO close http client
+}
+
+func getSematextMetricType(metricType telegraf.ValueType) SematextMetricType {
+	var semType SematextMetricType
+	switch metricType {
+	case telegraf.Counter:
+		semType = Counter
+	default:
+		semType = Gauge
+	}
+
+	return semType
+}
+
+func getSematextNumericType(field *telegraf.Field) NumericType {
+	var numType NumericType
+	switch field.Value.(type) {
+	case float64:
+		numType = Double
+	case uint64:
+		numType = Long
+	case int64:
+		numType = Long
+	case bool:
+		numType = Bool
+	default:
+		numType = UnsupportedNumericType
+	}
+
+	return numType
+}
+
+func buildMetricKey(host string, namespace string, name string) string {
+	return fmt.Sprintf("%s-%s.%s", host, namespace, name)
+}

--- a/plugins/outputs/sematext/processors/metainfo.go
+++ b/plugins/outputs/sematext/processors/metainfo.go
@@ -92,7 +92,7 @@ func (m *Metainfo) Process(metrics []telegraf.Metric) ([]telegraf.Metric, error)
 
 	for _, metric := range metrics {
 		for _, field := range metric.FieldList() {
-			mInfo, mKey := processMetric(m.token, &metric, field, m.sentMetrics)
+			mInfo, mKey := processMetric(m.token, metric, field, m.sentMetrics)
 			if mInfo != nil {
 				newMetrics[mKey] = mInfo
 			}
@@ -168,12 +168,12 @@ func (m *Metainfo) sendMetainfo(newMetrics map[string]*MetricMetainfo) {
 	}
 }
 
-func processMetric(token string, metric *telegraf.Metric, field *telegraf.Field,
+func processMetric(token string, metric telegraf.Metric, field *telegraf.Field,
 	sentMetrics map[string]*MetricMetainfo) (*MetricMetainfo, string) {
-	host, set := (*metric).GetTag(telegrafHostTag)
+	host, set := metric.GetTag(telegrafHostTag)
 	// skip if no host tag
 	if set {
-		key := buildMetricKey(host, (*metric).Name(), field.Key)
+		key := buildMetricKey(host, metric.Name(), field.Key)
 
 		_, set := sentMetrics[key]
 		if !set {
@@ -184,20 +184,20 @@ func processMetric(token string, metric *telegraf.Metric, field *telegraf.Field,
 	return nil, ""
 }
 
-func buildMetainfo(token string, host string, metric *telegraf.Metric, field *telegraf.Field) *MetricMetainfo {
-	semType := getSematextMetricType((*metric).Type())
+func buildMetainfo(token string, host string, metric telegraf.Metric, field *telegraf.Field) *MetricMetainfo {
+	semType := getSematextMetricType(metric.Type())
 	numericType := getSematextNumericType(field)
 
 	if numericType == UnsupportedNumericType || numericType == Bool {
 		return nil
 	}
 
-	label := fmt.Sprintf("%s.%s", (*metric).Name(), field.Key)
+	label := fmt.Sprintf("%s.%s", metric.Name(), field.Key)
 
 	return &MetricMetainfo{
 		token:       token,
 		name:        field.Key,
-		namespace:   (*metric).Name(),
+		namespace:   metric.Name(),
 		semType:     semType,
 		numericType: numericType,
 		label:       label,

--- a/plugins/outputs/sematext/processors/metainfo.go
+++ b/plugins/outputs/sematext/processors/metainfo.go
@@ -92,7 +92,7 @@ func (m *Metainfo) Process(metrics []telegraf.Metric) ([]telegraf.Metric, error)
 
 	for _, metric := range metrics {
 		for _, field := range metric.FieldList() {
-			mInfo, mKey := processMetric(m.token, &metric, field, &m.sentMetrics)
+			mInfo, mKey := processMetric(m.token, &metric, field, m.sentMetrics)
 			if mInfo != nil {
 				newMetrics[mKey] = mInfo
 			}
@@ -115,7 +115,7 @@ func (m *Metainfo) Process(metrics []telegraf.Metric) ([]telegraf.Metric, error)
 func (m *Metainfo) sendMetainfo(newMetrics map[string]*MetricMetainfo) {
 	reqCounter := 0
 
-	mInfoSlice := make([]*MetricMetainfo, len(newMetrics))
+	mInfoSlice := make([]*MetricMetainfo, 0, len(newMetrics))
 	for _, mInfo := range newMetrics {
 		mInfoSlice = append(mInfoSlice, mInfo)
 	}
@@ -169,13 +169,13 @@ func (m *Metainfo) sendMetainfo(newMetrics map[string]*MetricMetainfo) {
 }
 
 func processMetric(token string, metric *telegraf.Metric, field *telegraf.Field,
-	sentMetrics *map[string]*MetricMetainfo) (*MetricMetainfo, string) {
+	sentMetrics map[string]*MetricMetainfo) (*MetricMetainfo, string) {
 	host, set := (*metric).GetTag(telegrafHostTag)
 	// skip if no host tag
 	if set {
 		key := buildMetricKey(host, (*metric).Name(), field.Key)
 
-		_, set := (*sentMetrics)[key]
+		_, set := sentMetrics[key]
 		if !set {
 			return buildMetainfo(token, host, metric, field), key
 		}

--- a/plugins/outputs/sematext/processors/metainfo_serializer.go
+++ b/plugins/outputs/sematext/processors/metainfo_serializer.go
@@ -1,0 +1,48 @@
+package processors
+
+import (
+	"bytes"
+	"github.com/influxdata/telegraf"
+	"strings"
+)
+
+type MetainfoSerializer struct {
+	log telegraf.Logger
+}
+
+func (m *MetainfoSerializer) Write(mList []*MetricMetainfo) []byte {
+	var output bytes.Buffer
+
+	for _, meta := range mList {
+		output.Write(serializeMetainfo(meta))
+		output.WriteString("\n")
+	}
+
+	return output.Bytes()
+}
+
+func serializeMetainfo(metainfo *MetricMetainfo) []byte {
+	var output bytes.Buffer
+
+	output.WriteString((*metainfo).namespace)
+	output.WriteString(",label=")
+	output.WriteString((*metainfo).label)
+	output.WriteString(",numericType=")
+	output.WriteString(strings.ToLower((*metainfo).numericType.String()))
+	output.WriteString(",os.host=")
+	output.WriteString((*metainfo).host)
+	output.WriteString(",token=")
+	output.WriteString((*metainfo).token)
+	output.WriteString(",type=")
+	output.WriteString(strings.ToLower((*metainfo).semType.String()))
+	output.WriteString(" ")
+	output.WriteString((*metainfo).name)
+
+	return output.Bytes()
+}
+
+func NewMetainfoSerializer(log telegraf.Logger) *MetainfoSerializer {
+	return &MetainfoSerializer{
+		log: log,
+	}
+}

--- a/plugins/outputs/sematext/processors/metainfo_serializer_test.go
+++ b/plugins/outputs/sematext/processors/metainfo_serializer_test.go
@@ -1,0 +1,22 @@
+package processors
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSerializeMetainfo(t *testing.T) {
+	mInfo := &MetricMetainfo{
+		name:        "cpu.user",
+		namespace:   "os",
+		label:       "os.cpu.user",
+		semType:     Gauge,
+		numericType: Long,
+		token:       "token",
+		host:        "host001",
+	}
+
+	body := string(serializeMetainfo(mInfo))
+
+	assert.Equal(t, "os,label=os.cpu.user,numericType=long,os.host=host001,token=token,type=gauge cpu.user", body)
+}

--- a/plugins/outputs/sematext/processors/metainfo_test.go
+++ b/plugins/outputs/sematext/processors/metainfo_test.go
@@ -1,0 +1,115 @@
+package processors
+
+import (
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestProcessMetric(t *testing.T) {
+	now := time.Now()
+	m, _ := metric.New(
+		"os",
+		map[string]string{telegrafHostTag: "somehost", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
+		now)
+
+	sentMetrics := make(map[string]*MetricMetainfo, 0)
+
+	mInfo := processMetric("aaa", &m, getField(m, "disk.used"), &sentMetrics)
+	mKey := buildMetricKey("somehost", "os", "disk.used")
+	assert.NotNil(t, mInfo)
+
+	sentMetrics[mKey] = mInfo
+	// once it is in sentMetrics, it shouldn't be created again
+	mInfo = processMetric("aaa", &m, getField(m, "disk.used"), &sentMetrics)
+	assert.Nil(t, mInfo)
+
+	sentMetrics[mKey] = nil
+	m.RemoveTag(telegrafHostTag)
+	mInfo = processMetric("aaa", &m, getField(m, "disk.used"), &sentMetrics)
+	assert.Nil(t, mInfo)
+}
+
+func TestBuildMetainfo(t *testing.T) {
+	now := time.Now()
+	m, _ := metric.New(
+		"os",
+		map[string]string{telegrafHostTag: "somehost", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
+		now)
+
+	mInfo := buildMetainfo("aaa", "host", &m, getField(m, "disk.used"))
+
+	assert.Equal(t, "aaa", mInfo.token)
+	assert.Equal(t, "host", mInfo.host)
+	assert.Equal(t, "os", mInfo.namespace)
+	assert.Equal(t, "disk.used", mInfo.name)
+	assert.Equal(t, Gauge, mInfo.semType)
+	assert.Equal(t, Double, mInfo.numericType)
+	assert.Equal(t, "os.disk.used", mInfo.label)
+	assert.Equal(t, "", mInfo.description)
+
+	m, _ = metric.New(
+		"os",
+		map[string]string{telegrafHostTag: "somehost", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
+		now, telegraf.Counter)
+	mInfo = buildMetainfo("aaa", "host", &m, getField(m, "disk.used"))
+
+	assert.Equal(t, Counter, mInfo.semType)
+
+	m, _ = metric.New(
+		"os",
+		map[string]string{telegrafHostTag: "somehost", "os.disk": "sda1"},
+		map[string]interface{}{"disk.state": "active"},
+		now, telegraf.Counter)
+	mInfo = buildMetainfo("aaa", "host", &m, getField(m, "disk.state"))
+	assert.Nil(t, mInfo)
+}
+
+func getField(m telegraf.Metric, name string) *telegraf.Field {
+	for _, f := range m.FieldList() {
+		if f.Key == name {
+			return f
+		}
+	}
+	return nil
+}
+
+func TestGetSematextMetricType(t *testing.T) {
+	assert.Equal(t, Gauge, getSematextMetricType(telegraf.Gauge))
+	assert.Equal(t, Counter, getSematextMetricType(telegraf.Counter))
+	assert.Equal(t, Gauge, getSematextMetricType(telegraf.Histogram))
+	assert.Equal(t, Gauge, getSematextMetricType(telegraf.Summary))
+	assert.Equal(t, Gauge, getSematextMetricType(telegraf.Untyped))
+}
+
+func TestGetSematextNumericType(t *testing.T) {
+	assert.Equal(t, Double, getSematextNumericType(&telegraf.Field{
+		Key:   "abc",
+		Value: 1.23,
+	}))
+	assert.Equal(t, Long, getSematextNumericType(&telegraf.Field{
+		Key:   "abc",
+		Value: int64(11),
+	}))
+	assert.Equal(t, Long, getSematextNumericType(&telegraf.Field{
+		Key:   "abc",
+		Value: uint64(11),
+	}))
+	assert.Equal(t, Bool, getSematextNumericType(&telegraf.Field{
+		Key:   "abc",
+		Value: true,
+	}))
+	assert.Equal(t, UnsupportedNumericType, getSematextNumericType(&telegraf.Field{
+		Key:   "abc",
+		Value: "abc",
+	}))
+}
+
+func TestBuildMetricKey(t *testing.T) {
+	assert.Equal(t, "host-os.cpu.user", buildMetricKey("host", "os", "cpu.user"))
+}

--- a/plugins/outputs/sematext/processors/metainfo_test.go
+++ b/plugins/outputs/sematext/processors/metainfo_test.go
@@ -18,17 +18,17 @@ func TestProcessMetric(t *testing.T) {
 
 	sentMetrics := make(map[string]*MetricMetainfo)
 
-	mInfo, mKey := processMetric("aaa", &m, getField(m, "disk.used"), sentMetrics)
+	mInfo, mKey := processMetric("aaa", m, getField(m, "disk.used"), sentMetrics)
 	assert.NotNil(t, mInfo)
 
 	sentMetrics[mKey] = mInfo
 	// once it is in sentMetrics, it shouldn't be created again
-	mInfo, mKey = processMetric("aaa", &m, getField(m, "disk.used"), sentMetrics)
+	mInfo, mKey = processMetric("aaa", m, getField(m, "disk.used"), sentMetrics)
 	assert.Nil(t, mInfo)
 
 	sentMetrics[mKey] = nil
 	m.RemoveTag(telegrafHostTag)
-	mInfo, _ = processMetric("aaa", &m, getField(m, "disk.used"), sentMetrics)
+	mInfo, _ = processMetric("aaa", m, getField(m, "disk.used"), sentMetrics)
 	assert.Nil(t, mInfo)
 }
 
@@ -40,7 +40,7 @@ func TestBuildMetainfo(t *testing.T) {
 		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
 		now)
 
-	mInfo := buildMetainfo("aaa", "host", &m, getField(m, "disk.used"))
+	mInfo := buildMetainfo("aaa", "host", m, getField(m, "disk.used"))
 
 	assert.Equal(t, "aaa", mInfo.token)
 	assert.Equal(t, "host", mInfo.host)
@@ -56,7 +56,7 @@ func TestBuildMetainfo(t *testing.T) {
 		map[string]string{telegrafHostTag: "somehost", "os.disk": "sda1"},
 		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
 		now, telegraf.Counter)
-	mInfo = buildMetainfo("aaa", "host", &m, getField(m, "disk.used"))
+	mInfo = buildMetainfo("aaa", "host", m, getField(m, "disk.used"))
 
 	assert.Equal(t, Counter, mInfo.semType)
 
@@ -65,7 +65,7 @@ func TestBuildMetainfo(t *testing.T) {
 		map[string]string{telegrafHostTag: "somehost", "os.disk": "sda1"},
 		map[string]interface{}{"disk.state": "active"},
 		now, telegraf.Counter)
-	mInfo = buildMetainfo("aaa", "host", &m, getField(m, "disk.state"))
+	mInfo = buildMetainfo("aaa", "host", m, getField(m, "disk.state"))
 	assert.Nil(t, mInfo)
 }
 

--- a/plugins/outputs/sematext/processors/metainfo_test.go
+++ b/plugins/outputs/sematext/processors/metainfo_test.go
@@ -16,20 +16,19 @@ func TestProcessMetric(t *testing.T) {
 		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
 		now)
 
-	sentMetrics := make(map[string]*MetricMetainfo, 0)
+	sentMetrics := make(map[string]*MetricMetainfo)
 
-	mInfo := processMetric("aaa", &m, getField(m, "disk.used"), &sentMetrics)
-	mKey := buildMetricKey("somehost", "os", "disk.used")
+	mInfo, mKey := processMetric("aaa", &m, getField(m, "disk.used"), &sentMetrics)
 	assert.NotNil(t, mInfo)
 
 	sentMetrics[mKey] = mInfo
 	// once it is in sentMetrics, it shouldn't be created again
-	mInfo = processMetric("aaa", &m, getField(m, "disk.used"), &sentMetrics)
+	mInfo, mKey = processMetric("aaa", &m, getField(m, "disk.used"), &sentMetrics)
 	assert.Nil(t, mInfo)
 
 	sentMetrics[mKey] = nil
 	m.RemoveTag(telegrafHostTag)
-	mInfo = processMetric("aaa", &m, getField(m, "disk.used"), &sentMetrics)
+	mInfo, _ = processMetric("aaa", &m, getField(m, "disk.used"), &sentMetrics)
 	assert.Nil(t, mInfo)
 }
 

--- a/plugins/outputs/sematext/processors/metainfo_test.go
+++ b/plugins/outputs/sematext/processors/metainfo_test.go
@@ -18,17 +18,17 @@ func TestProcessMetric(t *testing.T) {
 
 	sentMetrics := make(map[string]*MetricMetainfo)
 
-	mInfo, mKey := processMetric("aaa", &m, getField(m, "disk.used"), &sentMetrics)
+	mInfo, mKey := processMetric("aaa", &m, getField(m, "disk.used"), sentMetrics)
 	assert.NotNil(t, mInfo)
 
 	sentMetrics[mKey] = mInfo
 	// once it is in sentMetrics, it shouldn't be created again
-	mInfo, mKey = processMetric("aaa", &m, getField(m, "disk.used"), &sentMetrics)
+	mInfo, mKey = processMetric("aaa", &m, getField(m, "disk.used"), sentMetrics)
 	assert.Nil(t, mInfo)
 
 	sentMetrics[mKey] = nil
 	m.RemoveTag(telegrafHostTag)
-	mInfo, _ = processMetric("aaa", &m, getField(m, "disk.used"), &sentMetrics)
+	mInfo, _ = processMetric("aaa", &m, getField(m, "disk.used"), sentMetrics)
 	assert.Nil(t, mInfo)
 }
 

--- a/plugins/outputs/sematext/processors/processor.go
+++ b/plugins/outputs/sematext/processors/processor.go
@@ -13,7 +13,8 @@ type MetricProcessor interface {
 
 // BatchProcessor is used to execute actions on the level of a whole batch of metrics. Batch processors are run before
 // any Metric processors kick in, so metrics produced by a batch processor can count on further being decorated by
-// metric processors.
+// metric processors. Also, metrics batch processors work on are "original" Telegraf metrics without any Sematext
+// specific adjustments.
 type BatchProcessor interface {
 	Process(metrics []telegraf.Metric) ([]telegraf.Metric, error)
 

--- a/plugins/outputs/sematext/processors/utils.go
+++ b/plugins/outputs/sematext/processors/utils.go
@@ -1,6 +1,8 @@
 package processors
 
 import (
+	"io/ioutil"
+	"net/http"
 	"os"
 )
 
@@ -29,4 +31,13 @@ func exists(dir string) bool {
 		return false
 	}
 	return true
+}
+
+// response reads the response from the HTTP body.
+func response(r *http.Response) string {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return ""
+	}
+	return string(body)
 }

--- a/plugins/outputs/sematext/sematext.go
+++ b/plugins/outputs/sematext/sematext.go
@@ -78,10 +78,16 @@ func (s *Sematext) Init() error {
 		s.ReceiverURL = defaultSematextMetricsReceiverURL
 	}
 
-	proxyURL, err := url.Parse(s.ProxyServer)
-	if err != nil {
-		return fmt.Errorf("invalid url %s for the proxy server: %v", s.ProxyServer, err)
+	var proxyURL *url.URL = nil
+
+	if s.ProxyServer != "" {
+		var err error
+		proxyURL, err = url.Parse(s.ProxyServer)
+		if err != nil {
+			return fmt.Errorf("invalid url %s for the proxy server: %v", s.ProxyServer, err)
+		}
 	}
+
 	s.senderConfig = &sender.Config{
 		ProxyURL: proxyURL,
 		Username: s.Username,

--- a/plugins/outputs/sematext/sematext.go
+++ b/plugins/outputs/sematext/sematext.go
@@ -109,6 +109,7 @@ func (s *Sematext) initProcessors() {
 	}
 	s.batchProcessors = []processors.BatchProcessor{
 		processors.NewHeartbeat(),
+		processors.NewMetainfo(s.Log, s.Token, s.ReceiverURL, s.senderConfig),
 	}
 }
 

--- a/plugins/outputs/sematext/sematext.go
+++ b/plugins/outputs/sematext/sematext.go
@@ -92,7 +92,7 @@ func (s *Sematext) Init() error {
 
 	s.initProcessors()
 
-	s.serializer = serializer.NewMetricSerializer()
+	s.serializer = serializer.NewMetricSerializer(s.Log)
 
 	s.Log.Infof("Sematext output started with Token=%s, ReceiverUrl=%s, ProxyServer=%s", s.Token, s.ReceiverURL,
 		s.ProxyServer)

--- a/plugins/outputs/sematext/sender/sender.go
+++ b/plugins/outputs/sematext/sender/sender.go
@@ -60,7 +60,7 @@ func NewSender(config *Config) *Sender {
 // getProxyHeader creates proxy authentication header based on config settings
 func getProxyHeader(config *Config) string {
 	var proxyAuth string
-	if config.ProxyURL != nil && len(config.Username) > 0 && len(config.Password) > 0 {
+	if len(config.Username) > 0 && len(config.Password) > 0 {
 		auth := fmt.Sprintf("%s:%s", config.Username, config.Password)
 		proxyAuth = fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(auth)))
 	}

--- a/plugins/outputs/sematext/serializer/serializer.go
+++ b/plugins/outputs/sematext/serializer/serializer.go
@@ -23,13 +23,15 @@ type LinePerMetricSerializer struct {
 }
 
 // NewLinePerMetricSerializer creates an instance of NewLinePerMetricSerializer
-func NewLinePerMetricSerializer() *LinePerMetricSerializer {
-	return &LinePerMetricSerializer{}
+func NewLinePerMetricSerializer(log telegraf.Logger) *LinePerMetricSerializer {
+	return &LinePerMetricSerializer{
+		log: log,
+	}
 }
 
 // NewMetricSerializer creates and instance serializer which should be used to produce Sematext metrics format
-func NewMetricSerializer() MetricSerializer {
-	return &LinePerMetricSerializer{}
+func NewMetricSerializer(log telegraf.Logger) MetricSerializer {
+	return NewLinePerMetricSerializer(log)
 }
 
 // Write serializes input metrics array according to Sematext variant of influx line protocol. The output is returned

--- a/plugins/outputs/sematext/serializer/serializer_test.go
+++ b/plugins/outputs/sematext/serializer/serializer_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestWrite(t *testing.T) {
-	serializer := NewLinePerMetricSerializer()
-	serializer.log = testutil.Logger{}
+	serializer := NewLinePerMetricSerializer(testutil.Logger{})
 
 	now := time.Now()
 
@@ -32,8 +31,7 @@ func TestWrite(t *testing.T) {
 }
 
 func TestWriteNoTags(t *testing.T) {
-	serializer := NewLinePerMetricSerializer()
-	serializer.log = testutil.Logger{}
+	serializer := NewLinePerMetricSerializer(testutil.Logger{})
 
 	now := time.Now()
 
@@ -51,8 +49,7 @@ func TestWriteNoTags(t *testing.T) {
 }
 
 func TestWriteNoMetrics(t *testing.T) {
-	serializer := NewLinePerMetricSerializer()
-	serializer.log = testutil.Logger{}
+	serializer := NewLinePerMetricSerializer(testutil.Logger{})
 
 	now := time.Now()
 
@@ -68,8 +65,7 @@ func TestWriteNoMetrics(t *testing.T) {
 }
 
 func TestWriteMultipleTagsAndMetrics(t *testing.T) {
-	serializer := NewLinePerMetricSerializer()
-	serializer.log = testutil.Logger{}
+	serializer := NewLinePerMetricSerializer(testutil.Logger{})
 
 	now := time.Now()
 


### PR DESCRIPTION
This PR covers full metainfo logic:
- extraction from Telegraf metrics data
- serialization into format understood by Sematext backend
- sending the metainfo in a separate goroutine with retry logic in case response failed because of 5xx server error (exponential backoff, max 10 tries)