### PR TITLE
Node agents metric rename

### DIFF
--- a/plugins/outputs/sematext/processors/heartbeat.go
+++ b/plugins/outputs/sematext/processors/heartbeat.go
@@ -1,10 +1,11 @@
 package processors
 
 import (
-	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/metric"
 	"sync"
 	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 )
 
 const (
@@ -23,7 +24,7 @@ type Heartbeat struct {
 	lock            sync.Mutex
 }
 
-func NewHeartbeat() *Heartbeat {
+func NewHeartbeat() BatchProcessor {
 	return &Heartbeat{
 		injectedMinutes: make(map[int64]bool),
 	}

--- a/plugins/outputs/sematext/processors/heartbeat_test.go
+++ b/plugins/outputs/sematext/processors/heartbeat_test.go
@@ -1,11 +1,12 @@
 package processors
 
 import (
+	"testing"
+	"time"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestBuildHeartbeatMetric(t *testing.T) {
@@ -23,7 +24,8 @@ func TestBuildHeartbeatMetric(t *testing.T) {
 
 func TestHeartbeatNeeded(t *testing.T) {
 	minute := int64(11)
-	h := NewHeartbeat()
+	bp := NewHeartbeat()
+	h := bp.(*Heartbeat)
 	assert.Equal(t, true, h.heartbeatNeeded(minute))
 
 	h.injectedMinutes[minute] = true
@@ -34,7 +36,8 @@ func TestHeartbeatNeeded(t *testing.T) {
 }
 
 func TestAddHeartbeat(t *testing.T) {
-	h := NewHeartbeat()
+	bp := NewHeartbeat()
+	h := bp.(*Heartbeat)
 	now := time.Now()
 	currentMinute := getEpochMinute(now)
 
@@ -50,7 +53,8 @@ func TestAddHeartbeat(t *testing.T) {
 }
 
 func TestProcess(t *testing.T) {
-	h := NewHeartbeat()
+	bp := NewHeartbeat()
+	h := bp.(*Heartbeat)
 	metrics := make([]telegraf.Metric, 0, 2)
 
 	var err error
@@ -98,7 +102,8 @@ func TestFindMetricMinutes(t *testing.T) {
 }
 
 func TestResetMap(t *testing.T) {
-	h := NewHeartbeat()
+	bp := NewHeartbeat()
+	h := bp.(*Heartbeat)
 	h.injectedMinutes[123] = true
 	h.mapResetDay = 123
 

--- a/plugins/outputs/sematext/processors/host.go
+++ b/plugins/outputs/sematext/processors/host.go
@@ -1,12 +1,13 @@
 package processors
 
 import (
-	"github.com/influxdata/telegraf"
 	"io/ioutil"
 	"path"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/influxdata/telegraf"
 )
 
 const (
@@ -24,7 +25,7 @@ type Host struct {
 }
 
 // NewHost creates and initializes an instance of Host processor. It also starts periodic host reload goroutine.
-func NewHost(log telegraf.Logger) *Host {
+func NewHost(log telegraf.Logger) MetricProcessor {
 	// do the initial load before spawning a goroutine which will periodically reload the hostname
 	hostnameFileName := getHostnameFileName()
 

--- a/plugins/outputs/sematext/processors/rename.go
+++ b/plugins/outputs/sematext/processors/rename.go
@@ -8,6 +8,8 @@ var (
 	measurementReplaces = map[string]string{
 		"phpfpm":  "php",
 		"mongodb": "mongo",
+		"apache":  "apache",
+		"nginx":   "nginx",
 	}
 	fieldReplaces = map[string]string{
 		// apache
@@ -95,9 +97,10 @@ func NewRename() BatchProcessor { return &Rename{} }
 func (r *Rename) Process(points []telegraf.Metric) ([]telegraf.Metric, error) {
 	for _, point := range points {
 		replace, ok := measurementReplaces[point.Name()]
-		if ok {
-			point.SetName(replace)
+		if !ok {
+			continue
 		}
+		point.SetName(replace)
 		for _, field := range point.FieldList() {
 			key := point.Name() + "." + field.Key
 			replace, ok := fieldReplaces[key]

--- a/plugins/outputs/sematext/processors/rename.go
+++ b/plugins/outputs/sematext/processors/rename.go
@@ -1,0 +1,115 @@
+package processors
+
+import (
+	"github.com/influxdata/telegraf"
+)
+
+var (
+	measurementReplaces = map[string]string{
+		"phpfpm":  "php",
+		"mongodb": "mongo",
+	}
+	fieldReplaces = map[string]string{
+		// apache
+		"apache.BusyWorkers":          "apache.workers.busy",
+		"apache.BytesPerReq":          "apache.bytes",
+		"apache.ReqPerSec":            "apache.requests",
+		"apache.ConnsAsyncClosing":    "apache.connections.async.closing",
+		"apache.ConnsAsyncKeepAlive":  "apache.connections.async.keepAlive",
+		"apache.ConnsAsyncWriting":    "apache.connections.async.writing",
+		"apache.ConnsTotal":           "apache.connections",
+		"apache.IdleWorkers":          "apache.workers.idle",
+		"apache.scboard_closing":      "apache.workers.closing",
+		"apache.scboard_dnslookup":    "apache.workers.dns",
+		"apache.scboard_finishing":    "apache.workers.finishing",
+		"apache.scboard_idle_cleanup": "apache.workers.cleanup",
+		"apache.scboard_keepalive":    "apache.workers.keepalive",
+		"apache.scboard_logging":      "apache.workers.logging",
+		"apache.scboard_open":         "apache.workers.open",
+		"apache.scboard_reading":      "apache.workers.reading",
+		"apache.scboard_sending":      "apache.workers.sending",
+		"apache.scboard_starting":     "apache.workers.starting",
+		"apache.scboard_waiting":      "apache.workers.waiting",
+		"php.accepted_conn":           "php.fpm.requests.accepted.conns",
+		"php.listen_queue":            "php.fpm.queue.listen",
+		"php.max_listen_queue":        "php.fpm.queue.listen.max",
+		"php.listen_queue_len":        "php.fpm.queue.listen.len",
+		"php.idle_processes":          "php.fpm.process.idle",
+		"php.active_processes":        "php.fpm.process.active",
+		"php.total_processes":         "php.fpm.process.total",
+		"php.max_active_processes":    "php.fpm.process.active.max",
+		"php.max_children_reached":    "php.fpm.process.childrenReached.max",
+		"php.slow_requests":           "php.fpm.requests.slow",
+		// nginx
+		"nginx.accepts":  "nginx.requests.connections.accepted",
+		"nginx.handled":  "nginx.requests.connections.handled",
+		"nginx.active":   "nginx.requests.connections.active",
+		"nginx.reading":  "nginx.requests.connections.reading",
+		"nginx.writing":  "nginx.requests.connections.writing",
+		"nginx.waiting":  "nginx.requests.connections.waiting",
+		"nginx.requests": "nginx.request.count",
+		// mongodb
+		"mongo.flushes":                   "mongo.flushes",
+		"mongo.flushes_total_time_ns":     "mongo.flushes.time",
+		"mongo.document_inserted":         "mongo.documents.inserted",
+		"mongo.document_updated":          "mongo.documents.updated",
+		"mongo.document_deleted":          "mongo.documents.deleted",
+		"mongo.document_returned":         "mongo.documents.returned",
+		"mongo.resident_megabytes":        "mongo.memory.resident",
+		"mongo.vsize_megabytes":           "mongo.memory.virtual",
+		"mongo.mapped_megabytes":          "mongo.memory.mapped",
+		"mongo.inserts":                   "mongo.ops.insert",
+		"mongo.queries":                   "mongo.ops.query",
+		"mongo.updates":                   "mongo.ops.update",
+		"mongo.getmores":                  "mongo.ops.getmore",
+		"mongo.commands":                  "mongo.ops.command",
+		"mongo.repl_inserts":              "mongo.replica.ops.insert",
+		"mongo.repl_queries":              "mongo.replica.ops.query",
+		"mongo.repl_updates":              "mongo.replica.ops.update",
+		"mongo.repl_deletes":              "mongo.replica.ops.delete",
+		"mongo.repl_getmores":             "mongo.replica.ops.getmore",
+		"mongo.repl_commands":             "mongo.replica.ops.command",
+		"mongo.count_command_failed":      "mongo.commands.failed",
+		"mongo.count_command_total":       "mongo.commands.total",
+		"mongo.data_size":                 "mongo.database.data.size",
+		"mongo.storage_size":              "mongo.database.storage.size",
+		"mongo.index_size":                "mongo.database.index.size",
+		"mongo.collections":               "mongo.database.collections",
+		"mongo.objects":                   "mongo.database.objects",
+		"mongo.connections_current":       "mongo.network.connections",
+		"mongo.connections_total_created": "mongo.network.connections.total",
+		"net_in_bytes":                    "mongo.network.transfer.rx.rate",
+		"net_out_bytes":                   "mongo.network.transfer.tx.rate",
+		"mongo.open_connections":          "mongo.network.requests",
+	}
+)
+
+// Rename processor renames the measurement (metric) names
+// to match the existing metric names sent by Node.js agents
+type Rename struct{}
+
+// NewRename builds a new rename processor.
+func NewRename() BatchProcessor { return &Rename{} }
+
+// Process performs a lookup in the local maps of metric/field names
+// and replaces the metric name with the new name.
+func (r *Rename) Process(points []telegraf.Metric) ([]telegraf.Metric, error) {
+	for _, point := range points {
+		replace, ok := measurementReplaces[point.Name()]
+		if ok {
+			point.SetName(replace)
+		}
+		for _, field := range point.FieldList() {
+			key := point.Name() + "." + field.Key
+			replace, ok := fieldReplaces[key]
+			if !ok {
+				continue
+			}
+			point.RemoveField(field.Key)
+			point.AddField(replace, field.Value)
+		}
+	}
+	return points, nil
+}
+
+func (Rename) Close() {}

--- a/plugins/outputs/sematext/processors/rename.go
+++ b/plugins/outputs/sematext/processors/rename.go
@@ -80,7 +80,6 @@ var (
 		"mongo.connections_total_created": "mongo.network.connections.total",
 		"net_in_bytes":                    "mongo.network.transfer.rx.rate",
 		"net_out_bytes":                   "mongo.network.transfer.tx.rate",
-		"mongo.open_connections":          "mongo.network.requests",
 	}
 )
 

--- a/plugins/outputs/sematext/processors/rename_test.go
+++ b/plugins/outputs/sematext/processors/rename_test.go
@@ -1,0 +1,39 @@
+package processors
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRename(t *testing.T) {
+	r := Rename{}
+	m1 := newMetric("apache", nil, nil)
+	m2 := newMetric("phpfpm", nil, nil)
+	m3 := newMetric("apache", nil, map[string]interface{}{"scboard_dnslookup": 120})
+	m4 := newMetric("etcd", nil, map[string]interface{}{"slow_requests": 10})
+	m5 := newMetric("phpfpm", nil, map[string]interface{}{"slow_requests": 10})
+
+	results, err := r.Process([]telegraf.Metric{m1, m2, m3, m4, m5})
+	require.NoError(t, err)
+	assert.Equal(t, "apache", results[0].Name())
+	assert.Equal(t, "php", results[1].Name())
+	assert.Equal(t, "apache.workers.dns", results[2].FieldList()[0].Key)
+	assert.Equal(t, "slow_requests", results[3].FieldList()[0].Key)
+	assert.Equal(t, "php.fpm.requests.slow", results[4].FieldList()[0].Key)
+}
+
+func newMetric(name string, tags map[string]string, fields map[string]interface{}) telegraf.Metric {
+	if tags == nil {
+		tags = map[string]string{}
+	}
+	if fields == nil {
+		fields = map[string]interface{}{}
+	}
+	m, _ := metric.New(name, tags, fields, time.Now())
+	return m
+}

--- a/plugins/outputs/sematext/processors/token.go
+++ b/plugins/outputs/sematext/processors/token.go
@@ -17,7 +17,7 @@ func (t *Token) Process(metric telegraf.Metric) error {
 func (t *Token) Close() {}
 
 // NewToken creates a new token processor
-func NewToken(token string) *Token {
+func NewToken(token string) MetricProcessor {
 	return &Token{
 		Token: token,
 	}

--- a/plugins/outputs/sematext/sematext.go
+++ b/plugins/outputs/sematext/sematext.go
@@ -2,13 +2,14 @@ package sematext
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/outputs/sematext/processors"
 	"github.com/influxdata/telegraf/plugins/outputs/sematext/sender"
 	"github.com/influxdata/telegraf/plugins/outputs/sematext/serializer"
-	"net/http"
-	"net/url"
 )
 
 const (
@@ -108,6 +109,7 @@ func (s *Sematext) initProcessors() {
 		processors.NewHost(s.Log),
 	}
 	s.batchProcessors = []processors.BatchProcessor{
+		processors.NewRename(),
 		processors.NewHeartbeat(),
 	}
 }


### PR DESCRIPTION
The following mongodb metrics don't have the equivalent variant in Telegraf:

- mongo.journal.commits
- mongo.journal.commits.early
- mongo.journal.commits.time
- mongo.journal.commits.locked.time
- mongo.journal.data
- mongo.journal.data.written
- mongo.locks
- mongo.locks.wait
- mongo.locks.deadlock
- mongo.locks.acquiring.time.microsec
- mongo.memory.mapped.withjournal
-  mongo.network.requests
- mongo.database.file.size
- mongo.database.namespace.size