### PR TITLE
Handle counters

### DIFF
--- a/plugins/outputs/sematext/processors/counter.go
+++ b/plugins/outputs/sematext/processors/counter.go
@@ -1,0 +1,152 @@
+package processors
+
+import (
+	"bytes"
+	"github.com/influxdata/telegraf"
+	"math"
+	"sync"
+	"time"
+)
+
+// HandleCounter keeps track of previous values of counter-type metrics and converts their value into delta between
+// current and previous measurement.
+type HandleCounter struct {
+	lock          sync.Mutex
+	countersCache map[string]*counterCacheEntry
+	lastCleared   time.Time
+}
+
+type counterCacheEntry struct {
+	lastValue    interface{}
+	lastRecorded time.Time
+}
+
+// NewHandleCounter creates a new HandleCounter processor
+func NewHandleCounter() MetricProcessor {
+	return &HandleCounter{
+		lastCleared:   time.Now(),
+		countersCache: make(map[string]*counterCacheEntry),
+	}
+}
+
+func (h *HandleCounter) Process(metric telegraf.Metric) error {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	// if metric is a counter, keep track of its last recording, change the current value to be delta
+	if getSematextMetricType(metric.Type()) == Counter {
+		for _, field := range metric.FieldList() {
+			key := metric.Name() + "." + field.Key + "-" + getTagsKey(metric.Tags())
+			prevValueEntry := h.countersCache[key]
+			currValue := field.Value
+
+			var delta interface{}
+			if prevValueEntry == nil {
+				delta = getZeroValue(currValue)
+
+				h.countersCache[key] = &counterCacheEntry{
+					lastValue:    currValue,
+					lastRecorded: metric.Time(),
+				}
+			} else {
+				delta = calculateDelta(prevValueEntry.lastValue, currValue)
+
+				prevValueEntry.lastValue = currValue
+				prevValueEntry.lastRecorded = metric.Time()
+			}
+
+			field.Value = delta
+		}
+	}
+
+	h.clearCounterCache()
+
+	return nil
+}
+
+// clearCounterCache once a day goes through all entries in the cache map and removes all that were not used for the
+// past 24 hours
+func (h *HandleCounter) clearCounterCache() {
+	var now = time.Now()
+	if hoursSince(now, h.lastCleared) >= 24 {
+		newCountersCache := make(map[string]*counterCacheEntry)
+
+		for k, v := range h.countersCache {
+			if hoursSince(now, h.countersCache[k].lastRecorded) < 24 {
+				newCountersCache[k] = v
+			}
+		}
+
+		h.countersCache = newCountersCache
+		h.lastCleared = time.Now()
+	}
+}
+
+func hoursSince(end time.Time, start time.Time) float64 {
+	return (end.Sub(start)).Hours()
+}
+
+func getZeroValue(value interface{}) interface{} {
+	switch value.(type) {
+	case string:
+		return ""
+	case bool:
+		return false
+	case float64:
+		return 0.0
+	case uint64:
+		return 0
+	case int64:
+		return 0
+	default:
+		return 0
+	}
+}
+
+func calculateDelta(prevValue interface{}, currValue interface{}) interface{} {
+	switch v := prevValue.(type) {
+	case string:
+		return currValue
+	case bool:
+		return currValue
+	case float64:
+		if !math.IsNaN(v) && !math.IsInf(v, 0) && !math.IsNaN(currValue.(float64)) && !math.IsInf(currValue.(float64), 0) {
+			delta := currValue.(float64) - prevValue.(float64)
+			if delta < 0 {
+				delta = 0
+			}
+			return delta
+		} else {
+			return 0.0
+		}
+	case uint64:
+		delta := currValue.(uint64) - prevValue.(uint64)
+		if delta < 0 {
+			delta = 0
+		}
+		return delta
+	case int64:
+		delta := currValue.(int64) - prevValue.(int64)
+		if delta < 0 {
+			delta = 0
+		}
+		return delta
+	default:
+		return 0
+	}
+}
+
+func getTagsKey(tags map[string]string) string {
+	var output bytes.Buffer
+	for k, v := range tags {
+		output.WriteString(k)
+		output.WriteString("=")
+		output.WriteString(v)
+		output.WriteString(",")
+	}
+
+	return output.String()
+}
+
+func (h *HandleCounter) Close() {
+}

--- a/plugins/outputs/sematext/processors/counter_test.go
+++ b/plugins/outputs/sematext/processors/counter_test.go
@@ -1,0 +1,72 @@
+package processors
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestClearCounterCache(t *testing.T) {
+	now := time.Now()
+
+	lastCleared := time.Now().Add(-1 * time.Hour)
+	p := &HandleCounter{
+		lastCleared:   lastCleared,
+		countersCache: make(map[string]*counterCacheEntry),
+	}
+
+	p.countersCache["new"] = &counterCacheEntry{
+		lastValue:    123,
+		lastRecorded: time.Now().Add(-1 * time.Hour),
+	}
+	p.countersCache["old"] = &counterCacheEntry{
+		lastValue:    234,
+		lastRecorded: time.Now().Add(-30 * time.Hour),
+	}
+
+	p.clearCounterCache()
+
+	// nothing should have changed
+	assert.Equal(t, lastCleared.Unix(), p.lastCleared.Unix())
+	assert.Equal(t, 2, len(p.countersCache))
+	_, exists := p.countersCache["new"]
+	assert.Equal(t, true, exists)
+	_, exists = p.countersCache["old"]
+	assert.Equal(t, true, exists)
+
+	p.lastCleared = time.Now().Add(-25 * time.Hour)
+	p.clearCounterCache()
+
+	assert.True(t, p.lastCleared.Unix() >= now.Unix())
+	assert.Equal(t, 1, len(p.countersCache))
+	_, exists = p.countersCache["new"]
+	assert.Equal(t, true, exists)
+	_, exists = p.countersCache["old"]
+	assert.Equal(t, false, exists)
+}
+
+func TestHoursSince(t *testing.T) {
+	time1 := time.Date(2021, 04, 06, 10, 0, 0, 0, time.UTC)
+	time2 := time.Date(2021, 04, 06, 11, 0, 0, 0, time.UTC)
+
+	assert.Equal(t, 1, int(hoursSince(time2, time1)))
+}
+
+func TestGetZeroValue(t *testing.T) {
+	assert.Equal(t, "", getZeroValue("string"))
+	assert.Equal(t, false, getZeroValue(true))
+	assert.Equal(t, false, getZeroValue(false))
+	assert.Equal(t, 0.0, getZeroValue(float64(0)))
+	assert.Equal(t, 0, getZeroValue(uint64(0)))
+	assert.Equal(t, 0, getZeroValue(int64(0)))
+}
+
+func TestCalculateDelta(t *testing.T) {
+	assert.Equal(t, int64(10), calculateDelta(int64(10), int64(20)))
+	assert.Equal(t, float64(10), calculateDelta(float64(10), float64(20)))
+	assert.Equal(t, "def", calculateDelta("abc", "def"))
+}
+
+func TestGetTagsKey(t *testing.T) {
+	assert.Equal(t, "tag1=a,tag2=b,", getTagsKey(map[string]string{"tag1": "a", "tag2": "b"}))
+}

--- a/plugins/outputs/sematext/sematext.go
+++ b/plugins/outputs/sematext/sematext.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs/sematext/processors"
 	"github.com/influxdata/telegraf/plugins/outputs/sematext/sender"
 	"github.com/influxdata/telegraf/plugins/outputs/sematext/serializer"
+	"github.com/influxdata/telegraf/plugins/outputs/sematext/tags"
 	"net/http"
 	"net/url"
 )
@@ -159,6 +160,11 @@ func (s *Sematext) Write(metrics []telegraf.Metric) error {
 
 // processMetrics returns an error only when the whole batch of metrics should be discarded
 func (s *Sematext) processMetrics(metrics []telegraf.Metric) ([]telegraf.Metric, error) {
+	if metricsAlreadyProcessed(metrics) {
+		// in case some batch was fully processed before, we don't want to process it once again
+		return metrics, nil
+	}
+
 	for _, p := range s.batchProcessors {
 		var err error
 		metrics, err = p.Process(metrics)
@@ -173,21 +179,51 @@ func (s *Sematext) processMetrics(metrics []telegraf.Metric) ([]telegraf.Metric,
 
 	for _, metric := range metrics {
 		metricOk := true
-		for _, p := range s.metricProcessors {
-			err := p.Process(metric)
 
-			if err != nil {
-				// log the message, mark the metric to be skipped, skip other processors
-				s.Log.Warnf("can't process metric: %s in Sematext output, error : %s", metric, err.Error())
-				metricOk = false
-				break
+		// don't process the metrics that were already processed before
+		if !metricAlreadyProcessed(metric) {
+			for _, p := range s.metricProcessors {
+				err := p.Process(metric)
+
+				if err != nil {
+					// log the message, mark the metric to be skipped, skip other processors
+					s.Log.Warnf("can't process metric: %s in Sematext output, error : %s", metric, err.Error())
+					metricOk = false
+					break
+				}
 			}
 		}
+
 		if metricOk {
 			processedMetrics = append(processedMetrics, metric)
 		}
 	}
+
+	markMetricsProcessed(processedMetrics)
+
 	return processedMetrics, nil
+}
+
+func metricsAlreadyProcessed(metrics []telegraf.Metric) bool {
+	// return that batch hasn't been processed yet if any of its metrics hasn't been processed
+	for _, m := range metrics {
+		if metricAlreadyProcessed(m) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func metricAlreadyProcessed(metric telegraf.Metric) bool {
+	_, processed := metric.GetTag(tags.SematextProcessedTag)
+	return processed
+}
+
+func markMetricsProcessed(metrics []telegraf.Metric) {
+	for _, m := range metrics {
+		m.AddTag(tags.SematextProcessedTag, tags.SematextProcessedTag)
+	}
 }
 
 // TODO may not be needed as we have to rework how retry logic works depending on response status codes; sometimes

--- a/plugins/outputs/sematext/sematext.go
+++ b/plugins/outputs/sematext/sematext.go
@@ -113,6 +113,7 @@ func (s *Sematext) initProcessors() {
 	s.metricProcessors = []processors.MetricProcessor{
 		processors.NewToken(s.Token),
 		processors.NewHost(s.Log),
+		processors.NewHandleCounter(),
 	}
 	s.batchProcessors = []processors.BatchProcessor{
 		processors.NewHeartbeat(),

--- a/plugins/outputs/sematext/tags/tags.go
+++ b/plugins/outputs/sematext/tags/tags.go
@@ -1,0 +1,5 @@
+package tags
+
+const (
+	SematextProcessedTag = "sematext.processed"
+)


### PR DESCRIPTION
This PR adds:
- logic to process counter-type of metrics where instead of the "current value" (as prepared by Telegraf) we store the delta between current and previous value (as expected by Sematext backend). Internal cache of previous values is cleared once a day, we remove all entries that haven't appeared in the past 24 hours (and keep the rest so we avoid missing datapoints)
- this required us being able to recognize if some metrics were already processed in such a way before. The logic was added to handle that using a special sematext tag injected into metrics. Serializer had to be adjusted to not write such metric in its output.