### PR TITLE
Implement Compact metrics serializer

### DIFF
--- a/plugins/outputs/sematext/processors/container.go
+++ b/plugins/outputs/sematext/processors/container.go
@@ -7,23 +7,23 @@ import (
 )
 
 const (
-	CONTAINER_NAME_ENV_NAME         = "SEMATEXT_CONTAINER_NAME"
-	CONTAINER_ID_ENV_NAME           = "SEMATEXT_CONTAINER_ID"
-	CONTAINER_IMAGE_NAME_ENV_NAME   = "SEMATEXT_CONTAINER_IMAGE_NAME"
-	CONTAINER_IMAGE_TAG_ENV_NAME    = "SEMATEXT_CONTAINER_IMAGE_TAG"
-	CONTAINER_IMAGE_DIGEST_ENV_NAME = "SEMATEXT_CONTAINER_IMAGE_DIGEST"
-	K8S_POD_ENV_NAME                = "SEMATEXT_K8S_POD_NAME"
-	K8S_NAMESPACE_ENV_NAME          = "SEMATEXT_K8S_NAMESPACE"
-	K8S_CLUSTER_ENV_NAME            = "SEMATEXT_K8S_CLUSTER"
+	containerNameEnvName        = "SEMATEXT_CONTAINER_NAME"
+	containerIDEnvName          = "SEMATEXT_CONTAINER_ID"
+	containerImageNameEnvName   = "SEMATEXT_CONTAINER_IMAGE_NAME"
+	containerImageTagEnvName    = "SEMATEXT_CONTAINER_IMAGE_TAG"
+	containerImageDigestEnvName = "SEMATEXT_CONTAINER_IMAGE_DIGEST"
+	k8sPodEnvName               = "SEMATEXT_K8S_POD_NAME"
+	k8sNamespaceEnvName         = "SEMATEXT_K8S_NAMESPACE"
+	k8sClusterEnvName           = "SEMATEXT_K8S_CLUSTER"
 
-	CONTAINER_NAME_TAG         = "container.name"
-	CONTAINER_ID_TAG           = "container.id"
-	CONTAINER_IMAGE_NAME_TAG   = "container.image.name"
-	CONTAINER_IMAGE_TAG_TAG    = "container.image.tag"
-	CONTAINER_IMAGE_DIGEST_TAG = "container.image.digest"
-	K8S_POD_NAME_TAG           = "kubernetes.pod.name"
-	K8S_NAMESPACE_ID_TAG       = "kubernetes.namespace"
-	K8S_CLUSTER_TAG            = "kubernetes.cluster.name"
+	containerImageTag       = "container.name"
+	containerIDTag          = "container.id"
+	containerImageNameTag   = "container.image.name"
+	containerImageTagTag    = "container.image.tag"
+	containerImageDigestTag = "container.image.digest"
+	k8sPodNameTag           = "kubernetes.pod.name"
+	k8sNamespaceIDTag       = "kubernetes.namespace"
+	k8sClusterTag           = "kubernetes.cluster.name"
 )
 
 // ContainerTags is a metric processor that injects container tags read from env variables
@@ -34,15 +34,15 @@ type ContainerTags struct {
 // NewContainerTags creates new instance of container MetricProcessor
 func NewContainerTags() MetricProcessor {
 	tags := make(map[string]string)
-	tags[CONTAINER_NAME_TAG] = os.Getenv(CONTAINER_NAME_ENV_NAME)
-	tags[CONTAINER_ID_TAG] = os.Getenv(CONTAINER_ID_ENV_NAME)
-	tags[CONTAINER_IMAGE_NAME_TAG] = os.Getenv(CONTAINER_IMAGE_NAME_ENV_NAME)
-	tags[CONTAINER_IMAGE_TAG_TAG] = os.Getenv(CONTAINER_IMAGE_TAG_ENV_NAME)
-	tags[CONTAINER_IMAGE_DIGEST_TAG] = os.Getenv(CONTAINER_IMAGE_DIGEST_ENV_NAME)
+	tags[containerImageTag] = os.Getenv(containerNameEnvName)
+	tags[containerIDTag] = os.Getenv(containerIDEnvName)
+	tags[containerImageNameTag] = os.Getenv(containerImageNameEnvName)
+	tags[containerImageTagTag] = os.Getenv(containerImageTagEnvName)
+	tags[containerImageDigestTag] = os.Getenv(containerImageDigestEnvName)
 
-	tags[K8S_POD_NAME_TAG] = os.Getenv(K8S_POD_ENV_NAME)
-	tags[K8S_NAMESPACE_ID_TAG] = os.Getenv(K8S_NAMESPACE_ENV_NAME)
-	tags[K8S_CLUSTER_TAG] = os.Getenv(K8S_CLUSTER_ENV_NAME)
+	tags[k8sPodNameTag] = os.Getenv(k8sPodEnvName)
+	tags[k8sNamespaceIDTag] = os.Getenv(k8sNamespaceEnvName)
+	tags[k8sClusterTag] = os.Getenv(k8sClusterEnvName)
 	return &ContainerTags{
 		tags: tags,
 	}

--- a/plugins/outputs/sematext/processors/counter.go
+++ b/plugins/outputs/sematext/processors/counter.go
@@ -1,8 +1,8 @@
 package processors
 
 import (
-	"bytes"
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/outputs/sematext/tags"
 	"math"
 	"sync"
 	"time"
@@ -36,7 +36,7 @@ func (h *HandleCounter) Process(metric telegraf.Metric) error {
 	// if metric is a counter, keep track of its last recording, change the current value to be delta
 	if getSematextMetricType(metric.Type()) == Counter {
 		for _, field := range metric.FieldList() {
-			key := metric.Name() + "." + field.Key + "-" + getTagsKey(metric.Tags())
+			key := metric.Name() + "." + field.Key + "-" + tags.GetTagsKey(metric.Tags())
 			prevValueEntry := h.countersCache[key]
 			currValue := field.Value
 
@@ -133,18 +133,6 @@ func calculateDelta(prevValue interface{}, currValue interface{}) interface{} {
 	default:
 		return 0
 	}
-}
-
-func getTagsKey(tags map[string]string) string {
-	var output bytes.Buffer
-	for k, v := range tags {
-		output.WriteString(k)
-		output.WriteString("=")
-		output.WriteString(v)
-		output.WriteString(",")
-	}
-
-	return output.String()
 }
 
 func (h *HandleCounter) Close() {

--- a/plugins/outputs/sematext/processors/counter_test.go
+++ b/plugins/outputs/sematext/processors/counter_test.go
@@ -66,7 +66,3 @@ func TestCalculateDelta(t *testing.T) {
 	assert.Equal(t, float64(10), calculateDelta(float64(10), float64(20)))
 	assert.Equal(t, "def", calculateDelta("abc", "def"))
 }
-
-func TestGetTagsKey(t *testing.T) {
-	assert.Equal(t, "tag1=a,tag2=b,", getTagsKey(map[string]string{"tag1": "a", "tag2": "b"}))
-}

--- a/plugins/outputs/sematext/processors/metric_type.go
+++ b/plugins/outputs/sematext/processors/metric_type.go
@@ -15,7 +15,7 @@ type MetricType struct {
 
 // Process implements the core of MetricType processor logic
 func (m *MetricType) Process(metric telegraf.Metric) error {
-	if tagValue, set := metric.GetTag(metricTypeTagName); set == true {
+	if tagValue, set := metric.GetTag(metricTypeTagName); set {
 		metric.RemoveTag(metricTypeTagName)
 
 		for _, f := range metric.FieldList() {

--- a/plugins/outputs/sematext/processors/metric_type_test.go
+++ b/plugins/outputs/sematext/processors/metric_type_test.go
@@ -18,7 +18,9 @@ func TestMetricType(t *testing.T) {
 		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
 		now)
 
-	mt.Process(m)
+	err := mt.Process(m)
+
+	assert.Nil(t, err)
 
 	_, set := m.GetTag(metricTypeTagName)
 	assert.Equal(t, false, set)

--- a/plugins/outputs/sematext/serializer/serializer.go
+++ b/plugins/outputs/sematext/serializer/serializer.go
@@ -191,7 +191,7 @@ func (s *CompactMetricSerializer) Write(metrics []telegraf.Metric) []byte {
 		idToMetrics[id] = append(idToMetrics[id], m)
 	}
 
-	// sort the keys keep the order fixed
+	// sort the keys to keep the order fixed
 	sortedIds := make([]string, 0, len(idToMetrics))
 	for i := range idToMetrics {
 		sortedIds = append(sortedIds, i)
@@ -238,7 +238,7 @@ func serializeMetrics(metrics []telegraf.Metric) string {
 		return fieldList[i].Key < fieldList[j].Key
 	})
 
-	var countAdded = 0
+	countAdded := 0
 	for _, field := range fieldList {
 		var serializedMetric = serializeMetricField(field.Key, field.Value)
 
@@ -257,5 +257,5 @@ func serializeMetrics(metrics []telegraf.Metric) string {
 }
 
 func buildID(metric telegraf.Metric) string {
-	return fmt.Sprint(metric.Time().UnixNano()) + "-" + metric.Name() + "-" + tags.GetTagsKey(metric.Tags())
+	return strconv.FormatInt(metric.Time().UnixNano(), 10) + "-" + metric.Name() + "-" + tags.GetTagsKey(metric.Tags())
 }

--- a/plugins/outputs/sematext/serializer/serializer_test.go
+++ b/plugins/outputs/sematext/serializer/serializer_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/influxdata/telegraf/metric"
 )
 
-func TestWrite(t *testing.T) {
+func TestLinePerMetricSerializerWrite(t *testing.T) {
 	serializer := NewLinePerMetricSerializer(testutil.Logger{})
 
 	now := time.Now()
@@ -43,7 +43,7 @@ func TestWrite(t *testing.T) {
 		string(serializer.Write(metrics)))
 }
 
-func TestWriteNoTags(t *testing.T) {
+func TestLinePerMetricSerializerWriteNoTags(t *testing.T) {
 	serializer := NewLinePerMetricSerializer(testutil.Logger{})
 
 	now := time.Now()
@@ -61,7 +61,7 @@ func TestWriteNoTags(t *testing.T) {
 		string(serializer.Write(metrics)))
 }
 
-func TestWriteNoMetrics(t *testing.T) {
+func TestLinePerMetricSerializerWriteNoMetrics(t *testing.T) {
 	serializer := NewLinePerMetricSerializer(testutil.Logger{})
 
 	now := time.Now()
@@ -77,7 +77,7 @@ func TestWriteNoMetrics(t *testing.T) {
 	assert.Equal(t, "", string(serializer.Write(metrics)))
 }
 
-func TestWriteMultipleTagsAndMetrics(t *testing.T) {
+func TestLinePerMetricSerializerWriteMultipleTagsAndMetrics(t *testing.T) {
 	serializer := NewLinePerMetricSerializer(testutil.Logger{})
 
 	now := time.Now()
@@ -92,5 +92,186 @@ func TestWriteMultipleTagsAndMetrics(t *testing.T) {
 
 	assert.Equal(t,
 		fmt.Sprintf("os,os.disk=sda1,os.host=hostname disk.free=55i,disk.size=777i,disk.used=12.34 %d\n", now.UnixNano()),
+		string(serializer.Write(metrics)))
+}
+
+func TestCompactMetricSerializerWrite(t *testing.T) {
+	serializer := NewCompactMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m, _ := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname"},
+		map[string]interface{}{"disk.size": uint64(777)},
+		now)
+
+	metrics := []telegraf.Metric{m}
+
+	assert.Equal(t,
+		fmt.Sprintf("os,os.host=hostname disk.size=777i %d\n", now.UnixNano()),
+		string(serializer.Write(metrics)))
+
+	m, _ = metric.New(
+		"system",
+		map[string]string{"os.host": "hostname", "token": "token"},
+		map[string]interface{}{"uptime_format": "18 days, 22:37"},
+		now)
+
+	metrics = []telegraf.Metric{m}
+	assert.Equal(t,
+		// strings are temporarily filtered out (until Sematext backend gets support)
+		// fmt.Sprintf("system,os.host=hostname,token=token uptime_format=\"18 days, 22:37\" %d\n", now.UnixNano()),
+		"",
+		string(serializer.Write(metrics)))
+}
+
+func TestCompactMetricSerializerWriteNoTags(t *testing.T) {
+	serializer := NewCompactMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m, _ := metric.New(
+		"os",
+		map[string]string{},
+		map[string]interface{}{"disk.size": uint64(777)},
+		now)
+
+	metrics := []telegraf.Metric{m}
+
+	assert.Equal(t,
+		fmt.Sprintf("os disk.size=777i %d\n", now.UnixNano()),
+		string(serializer.Write(metrics)))
+}
+
+func TestCompactMetricSerializerWriteNoMetrics(t *testing.T) {
+	serializer := NewCompactMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m, _ := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname"},
+		map[string]interface{}{},
+		now)
+
+	metrics := []telegraf.Metric{m}
+
+	assert.Equal(t, "", string(serializer.Write(metrics)))
+}
+
+func TestCompactMetricSerializerWriteMultipleTagsAndMetrics(t *testing.T) {
+	serializer := NewCompactMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m, _ := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
+		now)
+
+	metrics := []telegraf.Metric{m}
+
+	assert.Equal(t,
+		fmt.Sprintf("os,os.disk=sda1,os.host=hostname disk.free=55i,disk.size=777i,disk.used=12.34 %d\n", now.UnixNano()),
+		string(serializer.Write(metrics)))
+}
+
+func TestCompactMetricSerializerWriteMultipleMetricsSingleLine(t *testing.T) {
+	serializer := NewCompactMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m1, _ := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34)},
+		now)
+
+	m2, _ := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.free": int64(55)},
+		now)
+
+	m3, _ := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.size": uint64(777)},
+		now)
+
+	metrics := []telegraf.Metric{m1, m2, m3}
+
+	assert.Equal(t,
+		fmt.Sprintf("os,os.disk=sda1,os.host=hostname disk.free=55i,disk.size=777i,disk.used=12.34 %d\n", now.UnixNano()),
+		string(serializer.Write(metrics)))
+}
+
+func TestCompactMetricSerializerWriteMultipleMetricsMultipleLines(t *testing.T) {
+	serializer := NewCompactMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m1, _ := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34)},
+		now)
+
+	m2, _ := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.free": int64(55)},
+		now)
+
+	m3, _ := metric.New(
+		"somethingelse",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.size": uint64(777)},
+		now)
+
+	metrics := []telegraf.Metric{m1, m2, m3}
+
+	assert.Equal(t,
+		fmt.Sprintf("os,os.disk=sda1,os.host=hostname disk.free=55i,disk.used=12.34 %d\n"+
+			"somethingelse,os.disk=sda1,os.host=hostname disk.size=777i %d\n", now.UnixNano(), now.UnixNano()),
+		string(serializer.Write(metrics)))
+}
+
+func TestCompactMetricSerializerWriteMultipleMetricsDifferentTimestamp(t *testing.T) {
+	serializer := NewCompactMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m1, _ := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34)},
+		now)
+
+	now2 := time.Now().AddDate(0, 0, 1)
+
+	m2, _ := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.free": int64(55)},
+		now2)
+
+	now3 := time.Now().AddDate(0, 0, 2)
+
+	m3, _ := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.size": uint64(777)},
+		now3)
+
+	metrics := []telegraf.Metric{m1, m2, m3}
+
+	assert.Equal(t,
+		fmt.Sprintf("os,os.disk=sda1,os.host=hostname disk.used=12.34 %d\n"+
+			"os,os.disk=sda1,os.host=hostname disk.free=55i %d\n"+
+			"os,os.disk=sda1,os.host=hostname disk.size=777i %d\n",
+			now.UnixNano(), now2.UnixNano(), now3.UnixNano()),
 		string(serializer.Write(metrics)))
 }

--- a/plugins/outputs/sematext/tags/tags.go
+++ b/plugins/outputs/sematext/tags/tags.go
@@ -1,5 +1,30 @@
 package tags
 
+import (
+	"bytes"
+	"sort"
+)
+
 const (
 	SematextProcessedTag = "sematext.processed"
 )
+
+func GetTagsKey(tags map[string]string) string {
+	var output bytes.Buffer
+
+	// sort tags to ensure the order
+	sortedTagKeys := make([]string, 0, len(tags))
+	for t := range tags {
+		sortedTagKeys = append(sortedTagKeys, t)
+	}
+	sort.Strings(sortedTagKeys)
+
+	for _, tagKey := range sortedTagKeys {
+		output.WriteString(tagKey)
+		output.WriteString("=")
+		output.WriteString(tags[tagKey])
+		output.WriteString(",")
+	}
+
+	return output.String()
+}

--- a/plugins/outputs/sematext/tags/tags_test.go
+++ b/plugins/outputs/sematext/tags/tags_test.go
@@ -1,0 +1,10 @@
+package tags
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetTagsKey(t *testing.T) {
+	assert.Equal(t, "tag1=a,tag2=b,", GetTagsKey(map[string]string{"tag1": "a", "tag2": "b"}))
+}


### PR DESCRIPTION
This PR adds the implementation of compact metrics serializer.

The idea is that the metrics that share the same namespace, tags+values and timestamp can be sent in a single influx line, instead each in a separate one. This is more optimal in terms of used network bandwidth and processing on our backend.

The default was now switched to use the compact serializer, but we still keep the old implementation as it will be much lighter on the agent (in case we have to switch back).