### PR TITLE
Tls config for sematext

### DIFF
--- a/plugins/outputs/sematext/sematext.go
+++ b/plugins/outputs/sematext/sematext.go
@@ -2,6 +2,7 @@ package sematext
 
 import (
 	"fmt"
+	"github.com/influxdata/telegraf/plugins/common/tls"
 	"net/http"
 	"net/url"
 
@@ -27,6 +28,7 @@ type Sematext struct {
 	Username    string          `toml:"username"`
 	Password    string          `toml:"password"`
 	Log         telegraf.Logger `toml:"-"`
+	tls.ClientConfig
 
 	metricsURL       string
 	sender           *sender.Sender
@@ -109,10 +111,16 @@ func (s *Sematext) Init() error {
 		}
 	}
 
+	tlsConfig, err := s.ClientConfig.TLSConfig()
+	if err != nil {
+		return err
+	}
+
 	s.senderConfig = &sender.Config{
-		ProxyURL: proxyURL,
-		Username: s.Username,
-		Password: s.Password,
+		ProxyURL:  proxyURL,
+		Username:  s.Username,
+		Password:  s.Password,
+		TLSConfig: tlsConfig,
 	}
 	s.sender = sender.NewSender(s.senderConfig)
 	s.metricsURL = s.ReceiverURL + "/write?db=metrics"

--- a/plugins/outputs/sematext/sender/sender.go
+++ b/plugins/outputs/sematext/sender/sender.go
@@ -3,6 +3,7 @@ package sender
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"fmt"
 	"net"
@@ -25,9 +26,10 @@ const (
 
 // Config contains sender configuration
 type Config struct {
-	ProxyURL *url.URL
-	Username string
-	Password string
+	ProxyURL  *url.URL
+	Username  string
+	Password  string
+	TLSConfig *tls.Config
 }
 
 // Sender is a simple wrapper around standard HTTP client
@@ -47,6 +49,9 @@ func NewSender(config *Config) *Sender {
 
 	if config.ProxyURL != nil {
 		transport.Proxy = http.ProxyURL(config.ProxyURL)
+	}
+	if config.TLSConfig != nil {
+		transport.TLSClientConfig = config.TLSConfig
 	}
 
 	c := &http.Client{


### PR DESCRIPTION
TLS config is added using the same config settings as for all other Telegraf outputs. 